### PR TITLE
fix: fix TracedHttpModule dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byndyusoft/nest-opentracing",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@byndyusoft/nest-opentracing",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@byndyusoft/nest-dynamic-module": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byndyusoft/nest-opentracing",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Nest.js implementation of opentracing",
   "publishConfig": {
     "access": "public"

--- a/src/clients/http/traced-http.module.ts
+++ b/src/clients/http/traced-http.module.ts
@@ -36,11 +36,11 @@ export class TracedHttpModule {
     return DynamicModuleHelper.registerAsync(
       {
         module: TracedHttpModule,
+        imports: options?.imports && options.imports.length > 0 ? [] : [HttpModule],
       },
       "ITracedHttpModuleOptions",
       {
         ...options,
-        imports: options?.imports && options.imports.length > 0 ? [] : [HttpModule],
         useFactory: async (...args: never[]) => Object.assign({}, defaultOptions, await options?.useFactory?.(...args)),
       },
     );


### PR DESCRIPTION
Reproduce code:

```typescript
import { TracedHttpModule } from "@byndyusoft/nest-opentracing";
import { HttpModule } from "@nestjs/axios";
import { Module } from "@nestjs/common";

const customHttpModule = HttpModule.registerAsync({
  useFactory: () => ({ baseURL: "http://localhost:8080" }),
});

@Module({
  imports: [
    customHttpModule,
    TracedHttpModule.registerAsync({
      imports: [customHttpModule],
      useFactory: () => ({
        logBodies: true,
      }),
    }),
  ],
})
export class TestModule {}
```

Reproduce repo: https://github.com/Byndyusoft/nest-template/tree/feature/custom-http-module-tracing-bug